### PR TITLE
Updates to allow customized template parameters and outputting to stdout

### DIFF
--- a/bin/underscorec
+++ b/bin/underscorec
@@ -7,11 +7,36 @@ var optimist = require('optimist')
         'description': 'Output File',
         'alias': 'output'
       },
+      'interpolate': {
+        'type': 'string',
+        'description': 'Underscore `interpolate` template setting',
+      },
+      'escape': {
+        'type': 'string',
+        'description': 'Underscore `escape` template setting',
+      },
+      'evaluate': {
+        'type': 'string',
+        'description': 'Underscore `evaluate` template setting',
+      },
+      'variable': {
+        'type': 'string',
+        'description': 'Underscore `variable` template setting',
+      },
     });
 
 var target = optimist.argv._[0],
-  output = optimist.argv.f;
+  output = optimist.argv.f,
+  _ = require('underscore'),
+  templateSettings = _.pick(optimist.argv, 'interpolate', 'escape', 'evaluate', 'variable');
+
+if(!target) {
+    console.error('Error.  Please specify template directory');
+    optimist.showHelp();
+    return 1;
+}
 
 var underscorec = require('../underscorec');
 
+underscorec.configure(templateSettings);
 underscorec.process(target, output);

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "dependencies": {
     "underscore": "~1.4.3",
     "optimist": "~0.3.5",
-    "shelljs": "~0.1.2"
+    "shelljs": "~0.1.2",
+    "rw": "0.0.4"
   },
   "devDependencies": {
     "mocha": "~1.8.1",

--- a/underscorec.js
+++ b/underscorec.js
@@ -1,12 +1,22 @@
 var shelljs = require('shelljs'),
   fs = require('fs'),
   path = require('path'),
-  _ = require('underscore');
+  _ = require('underscore'),
+  rw = require('rw'),
+  underscoreTemplateSettings = {};
+
 
 module.exports = {
 
+  configure: function(templateSettings) {
+    underscoreTemplateSettings = templateSettings;
+  },
+
   process: function (target, output) {
-    fs.writeFileSync(output, concat(readFiles(getTemplatePaths())), 'utf8', function (err) {
+
+    output = output || '/dev/stdout'
+
+    rw.writeSync(output, concat(readFiles(getTemplatePaths())), 'utf8', function (err) {
       if (err) {
         console.log(err);
       }
@@ -23,10 +33,10 @@ module.exports = {
 
     function readFiles(paths) {
       return paths.map(function (file) {
-        var source = _.template(fs.readFileSync(path.join(target,file), 'utf8')).source;
+        var source = _.template(fs.readFileSync(path.join(target,file), 'utf8'), null, underscoreTemplateSettings).source;
         var declaration = 'templates["' + file.split('.')[0] + '"] = ' + source;
         return {
-          'path': file, 
+          'path': file,
           declaration: declaration
         };
       });


### PR DESCRIPTION
I've added a few updates that I needed to use this code in my workflow.  If you don't specify an output file (-f) the output will now be sent to stdout.  I've also added 4 optional parameters that correlate with the underscore template parameters in case you are dealing with templates that require a different set of rules. 

Also I added a quick check to see if a template directory was included as an argument.  If its not a friendly error is thrown and the argument help screen dumps.  This should avoid errors with people running the command for the first time without arguments so they can see what is expected of them.
